### PR TITLE
Fix endpoint precedence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,11 @@ gradle-app.setting
 
 # Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
 !gradle-wrapper.jar
+
+
+#Ignore intellij project files
+.idea
+*.iml
+
+#Ignore .gradle dir
+.gradle

--- a/src/main/java/scmspain/karyon/restrouter/RestBasedRouter.java
+++ b/src/main/java/scmspain/karyon/restrouter/RestBasedRouter.java
@@ -6,7 +6,6 @@ import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.netflix.config.ConfigurationManager;
 import io.netty.buffer.ByteBuf;
-import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.reactivex.netty.protocol.http.server.HttpServerRequest;
 import io.reactivex.netty.protocol.http.server.HttpServerResponse;
@@ -17,7 +16,8 @@ import java.lang.reflect.Modifier;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.reflections.ReflectionUtils;
+import java.util.stream.Stream;
+
 import rx.Observable;
 import scmspain.karyon.restrouter.annotation.Endpoint;
 import scmspain.karyon.restrouter.annotation.Path;
@@ -26,6 +26,8 @@ import scmspain.karyon.restrouter.core.ResourceLoader;
 import scmspain.karyon.restrouter.core.URIParameterParser;
 import scmspain.karyon.restrouter.exception.ParamAnnotationException;
 import scmspain.karyon.restrouter.transport.http.RestUriRouter;
+
+import static org.reflections.ReflectionUtils.*;
 
 public class RestBasedRouter implements RequestHandler<ByteBuf, ByteBuf> {
 
@@ -36,53 +38,74 @@ public class RestBasedRouter implements RequestHandler<ByteBuf, ByteBuf> {
   private MethodParameterResolver rmParameterInjector;
   private ResourceLoader resourceLoader;
 
-  @Inject
-  public RestBasedRouter(Injector inject, URIParameterParser parameterParser, MethodParameterResolver rmParameterInjector, ResourceLoader resourceLoader) {
+  /**
+   * Wrapper class, used like a struct to encapsulate info regarding
+   * an endpoint method, and for the functional mapping and sorting below
+   */
+  private class EndpointDefinition {
+    String uri;
+    String verb;
+    Method method;
+    Class<?> klass;
 
+    EndpointDefinition(Method method, String uri, String verb) {
+      this.method = method;
+      this.klass = method.getDeclaringClass();
+      this.uri = uri;
+      this.verb = verb;
+    };
+  }
+
+  @Inject
+  public RestBasedRouter(Injector inject, URIParameterParser parameterParser,
+                         MethodParameterResolver rmParameterInjector, ResourceLoader resourceLoader) {
     this.injector = inject;
     this.parameterParser = parameterParser;
     this.rmParameterInjector = rmParameterInjector;
     this.resourceLoader = resourceLoader;
 
-
     String basePackage = ConfigurationManager.getConfigInstance().getString(BASE_PACKAGE_PROPERTY);
     Set<Class<?>> annotatedTypes = resourceLoader.find(basePackage, Endpoint.class);
 
-    for (Class endpoint : annotatedTypes) {
-      Set<Method> endpointMethods = ReflectionUtils.getAllMethods(endpoint,
-          Predicates.and(
-              ReflectionUtils.withModifier(Modifier.PUBLIC),
-              ReflectionUtils.withAnnotation(Path.class)),
-          ReflectionUtils.withReturnType(Observable.class));
+    annotatedTypes.stream()
+        .flatMap(klass->
+            getAllMethods(klass,
+                Predicates.and(withModifier(Modifier.PUBLIC), withAnnotation(Path.class)),
+                withReturnType(Observable.class)
+            ).stream())
+        .map(method -> {
+          Path path = method.getAnnotation(Path.class);
+          return new EndpointDefinition(method, path.value(), path.method());
+        })
+        //Double sorting, so we get the precedence right
+        .sorted((endpoint1, endpoint2) -> endpoint1.uri.indexOf("{") - endpoint2.uri.indexOf("{"))
+        .sorted((endpoint1, endpoint2) -> endpoint1.uri.compareTo(endpoint2.uri))
+        .forEach(endpoint -> {
+          Method method = endpoint.method;
+          String uriRegex = parameterParser.getUriRegex(endpoint.uri);
+          delegate.addUriRegex(uriRegex, endpoint.verb, (request, response) -> {
+            try {
+              Map<String, String> params = parameterParser.getParams(endpoint.uri, request.getUri());
+              Map<String, List<String>> queryParams = request.getQueryParameters();
+              Object[] invokeParams = rmParameterInjector.resolveParameters(method, request, response, params, queryParams);
+              return (Observable) method.invoke(injector.getInstance(endpoint.klass), invokeParams);
+            } catch (IllegalAccessException e) {
+              //Should never get here
+              response.setStatus(HttpResponseStatus.FORBIDDEN);
+              throw new RuntimeException("Exception invoking method: " + method.toString());
+            } catch (ParamAnnotationException e) {
+              response.setStatus(HttpResponseStatus.BAD_REQUEST);
+              return Observable.empty();
+            } catch (InvocationTargetException e) {
+              response.setStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
+              throw new RuntimeException("Exception invoking method " + method.toString(), e);
+            }
+          });
 
-      for (Method method : endpointMethods) {
-        Path path = method.getAnnotation(Path.class);
-        String uri = path.value();
-        String verb = path.method();
-        String uriRegex = parameterParser.getUriRegex(uri);
-        delegate.addUriRegex(uriRegex, verb, (request, response) -> {
-          try {
-            Map<String, String> params = parameterParser.getParams(uri, request.getUri());
-            Map<String, List<String>> queryParams = request.getQueryParameters();
-            Object[] invokeParams = rmParameterInjector.resolveParameters(method, request, response, params, queryParams);
-            return (Observable) method.invoke(injector.getInstance(endpoint), invokeParams);
-          } catch (IllegalAccessException e) {
-            //Should never get here
-            response.setStatus(HttpResponseStatus.FORBIDDEN);
-            throw new RuntimeException("Exception invoking method: " + method.toString());
-          } catch (ParamAnnotationException e) {
-            response.setStatus(HttpResponseStatus.BAD_REQUEST);
-            return Observable.empty();
-          } catch (InvocationTargetException e) {
-            response.setStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
-            throw new RuntimeException("Exception invoking method " + method.toString(), e);
-          }
         });
-      }
-    }
-
-
   }
+
+
 
   @Override
   public Observable<Void> handle(HttpServerRequest<ByteBuf> request, HttpServerResponse<ByteBuf> response) {

--- a/src/main/java/scmspain/karyon/restrouter/RestBasedRouter.java
+++ b/src/main/java/scmspain/karyon/restrouter/RestBasedRouter.java
@@ -16,7 +16,6 @@ import java.lang.reflect.Modifier;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Stream;
 
 import rx.Observable;
 import scmspain.karyon.restrouter.annotation.Endpoint;

--- a/src/main/java/scmspain/karyon/restrouter/transport/http/RestUriRouter.java
+++ b/src/main/java/scmspain/karyon/restrouter/transport/http/RestUriRouter.java
@@ -4,32 +4,35 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.reactivex.netty.protocol.http.server.HttpServerRequest;
 import io.reactivex.netty.protocol.http.server.HttpServerResponse;
 import io.reactivex.netty.protocol.http.server.RequestHandler;
+
+import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Supplier;
+
 import netflix.karyon.transport.http.HttpKeyEvaluationContext;
 import rx.Observable;
 
 
 public class RestUriRouter<I, O> implements RequestHandler<I, O> {
 
-
-  private final CopyOnWriteArrayList<Route> routes;
+  private final CopyOnWriteArrayList<Route<I,O>> routes;
 
   public RestUriRouter() {
-    routes = new CopyOnWriteArrayList<Route>();
+    routes = new CopyOnWriteArrayList<>();
   }
 
   @Override
   public Observable<Void> handle(HttpServerRequest<I> request, HttpServerResponse<O> response) {
-    HttpKeyEvaluationContext context = new HttpKeyEvaluationContext(response.getChannel());
-    for (Route route : routes) {
-      if (route.getKey().apply(request, context)) {
-        return route.getHandler().handle(request, response);
-      }
-    }
+    Supplier<Observable<Void>> notFoundResponse = (()-> {
+      response.setStatus(HttpResponseStatus.NOT_FOUND);
+      return response.close();
+    });
 
-    // None of the routes matched.
-    response.setStatus(HttpResponseStatus.NOT_FOUND);
-    return response.close();
+    Optional<Route<I,O>> bestRoute = findBestMatch(request, response);
+
+    return bestRoute
+        .map(r -> r.getHandler().handle(request, response))
+        .orElseGet(notFoundResponse);
   }
 
   /**
@@ -43,6 +46,19 @@ public class RestUriRouter<I, O> implements RequestHandler<I, O> {
   public RestUriRouter<I, O> addUriRegex(String uriRegEx, String verb, RequestHandler<I, O> handler) {
     routes.add(new Route(new EnhancedRegexUriConstraintKey<I>(uriRegEx, verb), handler));
     return this;
+  }
+
+  /**
+   * Find the best route for handling a request
+   * @param request
+   * @param response
+   */
+  private Optional<Route<I,O>> findBestMatch(HttpServerRequest<I> request, HttpServerResponse<O> response){
+    HttpKeyEvaluationContext context = new HttpKeyEvaluationContext(response.getChannel());
+
+    return routes.stream()
+        .filter(route -> route.getKey().apply(request, context))
+        .findFirst();
   }
 
 }

--- a/src/main/java/scmspain/karyon/restrouter/transport/http/RestUriRouter.java
+++ b/src/main/java/scmspain/karyon/restrouter/transport/http/RestUriRouter.java
@@ -7,7 +7,6 @@ import io.reactivex.netty.protocol.http.server.RequestHandler;
 
 import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.function.Supplier;
 
 import netflix.karyon.transport.http.HttpKeyEvaluationContext;
 import rx.Observable;
@@ -23,16 +22,14 @@ public class RestUriRouter<I, O> implements RequestHandler<I, O> {
 
   @Override
   public Observable<Void> handle(HttpServerRequest<I> request, HttpServerResponse<O> response) {
-    Supplier<Observable<Void>> notFoundResponse = (()-> {
-      response.setStatus(HttpResponseStatus.NOT_FOUND);
-      return response.close();
-    });
-
     Optional<Route<I,O>> bestRoute = findBestMatch(request, response);
 
     return bestRoute
         .map(r -> r.getHandler().handle(request, response))
-        .orElseGet(notFoundResponse);
+        .orElseGet(() -> {
+          response.setStatus(HttpResponseStatus.NOT_FOUND);
+          return response.close();
+        });
   }
 
   /**

--- a/src/test/java/scmspain/karyon/restrouter/KaryonRestRouterTest.java
+++ b/src/test/java/scmspain/karyon/restrouter/KaryonRestRouterTest.java
@@ -197,4 +197,14 @@ public class KaryonRestRouterTest {
                       .toBlocking().toFuture().get(10, TimeUnit.SECONDS);
       Assert.assertEquals("I'm the hardcoded one", body);
   }
+
+  @Test
+  public void testPathNotFound() throws Exception {
+    HttpResponseStatus status =
+        RxNetty.createHttpClient("localhost", AppServer.KaryonRestRouterModuleImpl.DEFAULT_PORT)
+            .submit(HttpClientRequest.createGet("/unexistant_path"))
+            .map(response -> response.getStatus())
+            .toBlocking().toFuture().get(10, TimeUnit.SECONDS);
+    Assert.assertEquals(HttpResponseStatus.NOT_FOUND, status);
+  }
 }

--- a/src/test/java/scmspain/karyon/restrouter/KaryonRestRouterTest.java
+++ b/src/test/java/scmspain/karyon/restrouter/KaryonRestRouterTest.java
@@ -183,6 +183,18 @@ public class KaryonRestRouterTest {
             .finallyDo(() -> finishLatch.countDown())
             .toBlocking().toFuture().get(10, TimeUnit.SECONDS);
     Assert.assertEquals("Example endpoint controller with DELETE!", body);
+  }
 
+  @Test
+  public void testEndpointPrecedence() throws Exception {
+      String body =
+              RxNetty.createHttpClient("localhost", AppServer.KaryonRestRouterModuleImpl.DEFAULT_PORT)
+                      .submit(HttpClientRequest.createGet("/example_path/hardcoded_param"))
+                      .flatMap(response -> {
+                          Assert.assertEquals(HttpResponseStatus.OK.code(), response.getStatus().code());
+                          return response.getContent().<String>map(content -> content.toString(Charset.defaultCharset()));
+                      })
+                      .toBlocking().toFuture().get(10, TimeUnit.SECONDS);
+      Assert.assertEquals("I'm the hardcoded one", body);
   }
 }

--- a/src/test/java/scmspain/karyon/restrouter/endpoint/ExampleEndpointController.java
+++ b/src/test/java/scmspain/karyon/restrouter/endpoint/ExampleEndpointController.java
@@ -86,6 +86,16 @@ public class ExampleEndpointController {
 
   }
 
+  //Test path precedence
+  @Path(value = "/example_path/hardcoded_param", method = HttpMethod.GET)
+  public Observable<Void> hardcodedPathEndpoint(HttpServerRequest<ByteBuf> request, HttpServerResponse<ByteBuf> response) {
+    return response.writeStringAndFlush("I'm the hardcoded one");
+  }
+
+  @Path(value = "/example_path/{parameterized_param}", method = HttpMethod.GET)
+  public Observable<Void> parameterizedPathEndpoint(HttpServerRequest<ByteBuf> request, @PathParam("parameterized_param") String p, HttpServerResponse<ByteBuf> response) {
+    return response.writeStringAndFlush("I'm the parameterized one");
+  }
 
 }
 


### PR DESCRIPTION
Fixes the precedence between two endpoints that could handle a request as shown in the failing test

As we discussed previously, I researched how the best suited annotated method for handling a request is chosen in spring-webmvc. There its done matching the request against every single route defined that could handle it.

Here, I went the other way(since I think it's simpler and more performant), and like the `SimpleRouter` does, it goes with the first one that matches. So, almost all of the logic changed is the one performed at the module initialization, where it gets all the relevant annotations and inserts them.
Before all that I just performed a double sorting so they get inserted in an order that gets the precedence right. We still get the simplicity  and predictability of the simpleRouter but with the added convenience