### PR TITLE
Feature/add multiple package scanning

### DIFF
--- a/src/main/java/scmspain/karyon/restrouter/RestRouterScanner.java
+++ b/src/main/java/scmspain/karyon/restrouter/RestRouterScanner.java
@@ -28,6 +28,7 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -111,8 +112,7 @@ public class RestRouterScanner {
     this.parameterParser = parameterParser;
     this.rmParameterInjector = rmParameterInjector;
 
-    String basePackage = ConfigurationManager.getConfigInstance().getString(BASE_PACKAGE_PROPERTY);
-    Set<Class<?>> annotatedTypes = resourceLoader.find(basePackage, Endpoint.class);
+    Set<Class<?>> annotatedTypes = getEndpointClasses(resourceLoader);
 
     annotatedTypes.stream()
         .flatMap(klass ->
@@ -130,7 +130,19 @@ public class RestRouterScanner {
         .forEach(this::configurePath);
   }
 
-  private void configurePath(PathDefinition pathDefinition) {
+  private Set<Class<?>> getEndpointClasses(ResourceLoader resourceLoader) {
+    String commaSeparatedPackages = ConfigurationManager.getConfigInstance().getString(BASE_PACKAGE_PROPERTY);
+    List<String> stringList = Arrays.asList(commaSeparatedPackages.split(","));
+    Set<Class<?>> annotatedTypes = new HashSet<>();
+
+    for (String packageName : stringList) {
+      annotatedTypes.addAll(resourceLoader.find(packageName, Endpoint.class));
+    }
+
+    return annotatedTypes;
+  }
+
+    private void configurePath(PathDefinition pathDefinition) {
     Method method = pathDefinition.method;
 
     boolean isCustomSerialization = isCustom(method);

--- a/src/main/java/scmspain/karyon/restrouter/RestRouterScanner.java
+++ b/src/main/java/scmspain/karyon/restrouter/RestRouterScanner.java
@@ -131,12 +131,10 @@ public class RestRouterScanner {
   }
 
   private Set<Class<?>> getEndpointClasses(ResourceLoader resourceLoader) {
-    List<String> stringList = Arrays.asList(ConfigurationManager.getConfigInstance().getStringArray(BASE_PACKAGE_PROPERTY));
+    List<String> packagesList = Arrays.asList(ConfigurationManager.getConfigInstance().getStringArray(BASE_PACKAGE_PROPERTY));
     Set<Class<?>> annotatedTypes = new HashSet<>();
 
-    for (String packageName : stringList) {
-      annotatedTypes.addAll(resourceLoader.find(packageName.trim(), Endpoint.class));
-    }
+    packagesList.stream().forEach(packageName -> annotatedTypes.addAll(resourceLoader.find(packageName.trim(), Endpoint.class)));
 
     return annotatedTypes;
   }

--- a/src/main/java/scmspain/karyon/restrouter/RestRouterScanner.java
+++ b/src/main/java/scmspain/karyon/restrouter/RestRouterScanner.java
@@ -131,12 +131,11 @@ public class RestRouterScanner {
   }
 
   private Set<Class<?>> getEndpointClasses(ResourceLoader resourceLoader) {
-    String commaSeparatedPackages = ConfigurationManager.getConfigInstance().getString(BASE_PACKAGE_PROPERTY);
-    List<String> stringList = Arrays.asList(commaSeparatedPackages.split(","));
+    List<String> stringList = Arrays.asList(ConfigurationManager.getConfigInstance().getStringArray(BASE_PACKAGE_PROPERTY));
     Set<Class<?>> annotatedTypes = new HashSet<>();
 
     for (String packageName : stringList) {
-      annotatedTypes.addAll(resourceLoader.find(packageName, Endpoint.class));
+      annotatedTypes.addAll(resourceLoader.find(packageName.trim(), Endpoint.class));
     }
 
     return annotatedTypes;

--- a/src/test/java/scmspain/karyon/restrouter/RestRouterScannerTest.java
+++ b/src/test/java/scmspain/karyon/restrouter/RestRouterScannerTest.java
@@ -8,6 +8,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
+import org.mockito.Matchers;
 import org.mockito.Mock;
 import rx.Observable;
 import scmspain.karyon.restrouter.annotation.Endpoint;
@@ -16,6 +17,8 @@ import scmspain.karyon.restrouter.annotation.Produces;
 import scmspain.karyon.restrouter.core.MethodParameterResolver;
 import scmspain.karyon.restrouter.core.ResourceLoader;
 import scmspain.karyon.restrouter.core.URIParameterParser;
+import scmspain.karyon.restrouter.dummy.DummyController;
+import scmspain.karyon.restrouter.endpoint.ExampleEndpointController;
 import scmspain.karyon.restrouter.transport.http.RestUriRouter;
 
 import java.util.Collection;
@@ -26,6 +29,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -167,6 +171,23 @@ public class RestRouterScannerTest {
     verify(restUriRouter).addUriRegex(any(), any(), any(), any(), eq(true), any());
   }
 
+  @Test
+  public void givenScanPropertyWithTwoPackagesWhenScanningThenHitsInTwoPackages() throws Exception {
+    given(resourceLoader.find(eq("scmspain.karyon.restrouter.endpoint"), eq(Endpoint.class)))
+      .willReturn(Sets.newHashSet(ExampleEndpointController.class));
+
+    given(resourceLoader.find(eq("scmspain.karyon.restrouter.dummy"), eq(Endpoint.class)))
+      .willReturn(Sets.newHashSet(DummyController.class));
+
+    new RestRouterScanner(injector, parameterParser,
+        rmParameterInjector, resourceLoader, restUriRouter);
+
+    verify(restUriRouter, atLeastOnce()).addUriRegex(
+            Matchers.contains("ExampleEndpointController"), any(), any(), any(), eq(true), any());
+
+    verify(restUriRouter, atLeastOnce()).addUriRegex(
+            Matchers.contains("DummyController"), any(), any(), any(), eq(true), any());
+  }
 
   @Endpoint
   static class WithoutPathsAndMethods {

--- a/src/test/java/scmspain/karyon/restrouter/dummy/DummyController.java
+++ b/src/test/java/scmspain/karyon/restrouter/dummy/DummyController.java
@@ -1,0 +1,21 @@
+package scmspain.karyon.restrouter.dummy;
+
+import rx.Observable;
+import scmspain.karyon.restrouter.annotation.Endpoint;
+import scmspain.karyon.restrouter.annotation.Path;
+
+import javax.ws.rs.HttpMethod;
+
+/**
+ * Created by ruben.perez on 16/11/15.
+ */
+@Endpoint
+public class DummyController {
+
+    @Path(value = "/dummy/{id}", method = HttpMethod.GET)
+    public Observable<Void> method() {
+
+        return Observable.empty();
+    }
+
+}

--- a/src/test/resources/AppServer.properties
+++ b/src/test/resources/AppServer.properties
@@ -1,1 +1,2 @@
-com.scmspain.karyon.rest.property.packages = scmspain.karyon.restrouter.endpoint
+# Multi value (comma-separated) property
+com.scmspain.karyon.rest.property.packages = scmspain.karyon.restrouter.endpoint,scmspain.karyon.restrouter.dummy


### PR DESCRIPTION
Allow multiple values (comma-separated)  for the "com.scmspain.karyon.rest.property.packages" property. With that enabled, we could have a project specific package for its own controllers, and also the health check controller provided by the [karyon2-healthcheck](https://github.com/scm-spain/karyon2-healthcheck) project.