### PR TITLE
Now serializer is not required

### DIFF
--- a/src/main/java/scmspain/karyon/restrouter/RestRouterHandler.java
+++ b/src/main/java/scmspain/karyon/restrouter/RestRouterHandler.java
@@ -40,7 +40,6 @@ public class RestRouterHandler implements RequestHandler<ByteBuf, ByteBuf> {
 
   private static final Logger L = LoggerFactory.getLogger(RestRouterHandler.class);
 
-
   /**
    * Creates an instance
    * @param restUriRouter the rest uri router
@@ -87,7 +86,7 @@ public class RestRouterHandler implements RequestHandler<ByteBuf, ByteBuf> {
         .orElse(new RouteNotFound<>());
     Observable<Void> result;
 
-    if (route.isCustomSerialization()) {
+    if (route.isCustomSerialization() || !serializerManager.hasSerializers()) {
       result = handleCustomSerialization(route, request, response);
 
     } else {

--- a/src/main/java/scmspain/karyon/restrouter/serializer/SerializeManager.java
+++ b/src/main/java/scmspain/karyon/restrouter/serializer/SerializeManager.java
@@ -32,11 +32,13 @@ public class SerializeManager {
   }
 
   @Inject
-  private void validate() {
-    getSerializer(defaultContentType)
-        .orElseThrow(() ->
-          new RuntimeException("There is no serializer configured for the default content type")
-    );
+  void validate() {
+    if(hasSerializers()) {
+      getSerializer(defaultContentType)
+          .orElseThrow(() ->
+              new RuntimeException("There is no serializer configured for the default content type")
+          );
+    }
   }
 
   private void setSerializers(List<Serializer> serializers) {
@@ -70,6 +72,10 @@ public class SerializeManager {
    */
   public Optional<Serializer> getSerializer(String contentType) {
     return Optional.ofNullable(serializers.get(contentType));
+  }
+
+  public boolean hasSerializers() {
+    return !serializers.isEmpty();
   }
 
 }

--- a/src/test/java/scmspain/karyon/restrouter/serializer/SerializeManagerTest.java
+++ b/src/test/java/scmspain/karyon/restrouter/serializer/SerializeManagerTest.java
@@ -1,0 +1,58 @@
+package scmspain.karyon.restrouter.serializer;
+
+import org.junit.Test;
+
+import java.io.OutputStream;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Created by pablo.diaz on 19/11/15.
+ */
+public class SerializeManagerTest {
+
+
+
+  @Test
+  public void givenASerializerManagerWithSerializersThatSupportsDefaultContentTypeWhenValidateItShouldValidate() throws Exception {
+    List<Serializer> serializers = Collections.singletonList(createSerializer("application/json"));
+
+    SerializeManager serializeManager = new SerializeManager(serializers, "application/json");
+
+    serializeManager.validate();
+  }
+
+
+  @Test(expected = RuntimeException.class)
+  public void givenASerializerManagerWithSerializersThatDoesntSupportsDefaultContentTypeWhenValidateItShouldNotValidate() throws Exception {
+    List<Serializer> serializers = Collections.singletonList(createSerializer("application/json"));
+
+    SerializeManager serializeManager = new SerializeManager(serializers, "default_not_supported");
+
+    serializeManager.validate();
+  }
+
+  @Test
+  public void givenASerializerManagerWithoutSerializersWhenValidateItShouldValidateCorrectly() throws Exception {
+    List<Serializer> serializers = Collections.emptyList();
+
+    SerializeManager serializeManager = new SerializeManager(serializers, "whatever");
+
+    serializeManager.validate();
+  }
+
+  private Serializer createSerializer(String... contentTypes) {
+    return new Serializer(contentTypes) {
+      @Override
+      public void serialize(Object obj, OutputStream outputStream) {
+
+      }
+    };
+  }
+}


### PR DESCRIPTION
Now serializer is not required if there isn't a route that needs serialization as @albertoramirezscmspain reported :)
Corrected also problems with 4xx status codes when the serializer is not set.
Added more tests to ensure works as expected