### PR TITLE
Feature/expose hystrix metrics

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     compile 'com.netflix.karyon:karyon2-governator:2.5.1'
     compile 'org.reflections:reflections:0.9.9'
     compile 'org.commonjava.mimeparse:mimeparse:0.1.3.3'
+    compile 'com.netflix.hystrix:hystrix-rx-netty-metrics-stream:1.4.20'
 }
 
 nexusStaging {

--- a/src/main/java/scmspain/karyon/restrouter/KaryonRestRouterModule.java
+++ b/src/main/java/scmspain/karyon/restrouter/KaryonRestRouterModule.java
@@ -44,6 +44,7 @@ public abstract class KaryonRestRouterModule extends KaryonHttpModule<ByteBuf, B
     })
         .toProvider(errorHandlerProvider);
 
+    bind(RestRouterHandler.class);
     bindRouter().toProvider(RouteHandlerProvider.class);
 
   }

--- a/src/main/java/scmspain/karyon/restrouter/KaryonRestRouterModule.java
+++ b/src/main/java/scmspain/karyon/restrouter/KaryonRestRouterModule.java
@@ -44,7 +44,7 @@ public abstract class KaryonRestRouterModule extends KaryonHttpModule<ByteBuf, B
     })
         .toProvider(errorHandlerProvider);
 
-    bindRouter().to(RestRouterHandler.class);
+    bindRouter().toProvider(RouteHandlerProvider.class);
 
   }
 

--- a/src/main/java/scmspain/karyon/restrouter/RouteHandlerProvider.java
+++ b/src/main/java/scmspain/karyon/restrouter/RouteHandlerProvider.java
@@ -1,0 +1,34 @@
+package scmspain.karyon.restrouter;
+
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Provider;
+import com.netflix.hystrix.contrib.rxnetty.metricsstream.HystrixMetricsStreamHandler;
+import io.netty.buffer.ByteBuf;
+import io.reactivex.netty.protocol.http.server.RequestHandler;
+
+public class RouteHandlerProvider implements Provider<RequestHandler<ByteBuf, ByteBuf>> {
+
+  private final Injector injector;
+
+  @Inject
+  public RouteHandlerProvider(Injector injector) {
+    this.injector = injector;
+  }
+
+  @Override
+  public RequestHandler<ByteBuf, ByteBuf> get() {
+
+    RestRouterHandler restRouterHandler = this.injector.getInstance(RestRouterHandler.class);
+
+    if (isMetricsStreamEnabled()) {
+      return new HystrixMetricsStreamHandler<>(restRouterHandler);
+    }
+
+    return restRouterHandler;
+  }
+
+  public boolean isMetricsStreamEnabled() {
+    return true;
+  }
+}

--- a/src/main/java/scmspain/karyon/restrouter/RouteHandlerProvider.java
+++ b/src/main/java/scmspain/karyon/restrouter/RouteHandlerProvider.java
@@ -3,24 +3,27 @@ package scmspain.karyon.restrouter;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.Provider;
+import com.netflix.config.DynamicPropertyFactory;
 import com.netflix.hystrix.contrib.rxnetty.metricsstream.HystrixMetricsStreamHandler;
 import io.netty.buffer.ByteBuf;
 import io.reactivex.netty.protocol.http.server.RequestHandler;
 
 public class RouteHandlerProvider implements Provider<RequestHandler<ByteBuf, ByteBuf>> {
 
-  private final Injector injector;
+  public static final String PROP_EXPOSE_HYSTRIX_METRICS =
+    "com.scmspain.karyon.rest.property.exposeHystrixMetrics";
+
+  private final DynamicPropertyFactory properties = DynamicPropertyFactory.getInstance();
+  private final RequestHandler<ByteBuf, ByteBuf> restRouterHandler;
+  private final boolean defaultIsMetricsStreamEnabled = true;
 
   @Inject
   public RouteHandlerProvider(Injector injector) {
-    this.injector = injector;
+    restRouterHandler = injector.getInstance(RestRouterHandler.class);
   }
 
   @Override
   public RequestHandler<ByteBuf, ByteBuf> get() {
-
-    RestRouterHandler restRouterHandler = this.injector.getInstance(RestRouterHandler.class);
-
     if (isMetricsStreamEnabled()) {
       return new HystrixMetricsStreamHandler<>(restRouterHandler);
     }
@@ -29,6 +32,7 @@ public class RouteHandlerProvider implements Provider<RequestHandler<ByteBuf, By
   }
 
   public boolean isMetricsStreamEnabled() {
-    return true;
+    return properties.getBooleanProperty(
+      PROP_EXPOSE_HYSTRIX_METRICS, defaultIsMetricsStreamEnabled).get();
   }
 }

--- a/src/test/java/scmspain/karyon/restrouter/RouteHandlerProviderTest.java
+++ b/src/test/java/scmspain/karyon/restrouter/RouteHandlerProviderTest.java
@@ -1,0 +1,87 @@
+package scmspain.karyon.restrouter;
+
+import com.google.inject.Injector;
+import com.netflix.hystrix.contrib.rxnetty.metricsstream.HystrixMetricsStreamHandler;
+import io.netty.buffer.ByteBuf;
+import io.reactivex.netty.protocol.http.server.RequestHandler;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+
+public class RouteHandlerProviderTest {
+
+  private Injector mockedInjector;
+  private RouteHandlerProvider provider;
+  private RequestHandler<ByteBuf, ByteBuf> usingRouter;
+
+  @Before
+  public void setUp() {
+    mockedInjector = Mockito.mock(Injector.class);
+  }
+
+  @Test
+  public void itShouldReturnRestRouterHandlerWhenMetricsAreDisabledInConfiguration()
+    throws Exception {
+
+    givenMetricsDisabledByConfiguration();
+    whenRouteHandlerProviderIsInitialized();
+    andCallIt();
+    thenUseRestRouterHandler();
+  }
+
+  @Test
+  public void itShouldReturnHystrixMetricsStreamHandlerWhenEnabledInConfiguration()
+    throws Exception {
+
+    givenMetricsEnabledByConfiguration();
+    whenRouteHandlerProviderIsInitialized();
+    andCallIt();
+    thenHystrixMetricsStreamHandlerIsTheRouter();
+    andUseRestRouterHandlerAsDelegatedRouterHandler();
+  }
+
+  private void givenMetricsDisabledByConfiguration() throws Exception {
+    stubMetricsStateByConfiguration(false);
+  }
+
+  private void givenMetricsEnabledByConfiguration() throws Exception {
+    stubMetricsStateByConfiguration(true);
+  }
+
+  private void whenRouteHandlerProviderIsInitialized() {
+    provider = new RouteHandlerProvider(mockedInjector);
+  }
+
+  private void andCallIt() {
+    usingRouter = provider.get();
+  }
+
+  private void thenHystrixMetricsStreamHandlerIsTheRouter() {
+    assertThat(usingRouter, is(instanceOf(HystrixMetricsStreamHandler.class)));
+  }
+
+  private void thenUseRestRouterHandler() {
+    verify(mockedInjector, atLeastOnce()).getInstance(RestRouterHandler.class);
+  }
+
+  private void andUseRestRouterHandlerAsDelegatedRouterHandler() {
+    thenUseRestRouterHandler();
+  }
+
+  private void stubMetricsStateByConfiguration(boolean state) throws Exception {
+    RouteHandlerProvider mockedProvider = Mockito.mock(RouteHandlerProvider.class);
+    Mockito.when(mockedProvider.isMetricsStreamEnabled()).thenReturn(state);
+
+    PowerMockito
+      .whenNew(RouteHandlerProvider.class)
+      .withArguments(mockedInjector)
+      .thenReturn(mockedProvider);
+  }
+}

--- a/src/test/resources/AppServer.properties
+++ b/src/test/resources/AppServer.properties
@@ -1,2 +1,3 @@
 # Multi value (comma-separated) property
 com.scmspain.karyon.rest.property.packages = scmspain.karyon.restrouter.endpoint,scmspain.karyon.restrouter.dummy
+com.scmspain.karyon.rest.property.exposeHystrixMetrics=true


### PR DESCRIPTION
I open this PR to start discussing. I tested this working with two different micro services but I have problems due to #21, so I am not sure 100% this does not break anything, so please start to discuss but **not merge yet**.

**What?**
Basically this PR add **by default** an endpoint ```GET /hystrix.stream``` that exposes the Hystrix metrics as stream usable by both Hystrix Dashboard and Turbine (check out https://github.com/scm-spain/turbine-hystrix-dashboard for more information).

**How does it work?**
Using Ribbon in our micro services generates Hystrix Metrics (which we were not taking advantage of). That Hystrix metrics are readable in any point of our projects, so this PR exposes that metrics.

By using a Hystrix - RxNetty connector (https://github.com/Netflix/Hystrix/tree/master/hystrix-contrib/hystrix-rx-netty-metrics-stream), we have that endpoint that exposes metrics.

Router is now bound to a RouterProvider, which is in charge of check whether metrics must be exposed as stream (true by default but configurable via properties), if so, it returns ```HystrixMetricsStreamHandler``` using ```RestRouterHandler``` as delegated. Otherwise returns RestRouterHandler directly.

**Configuration**
By default this endpoint is exposed, but you can disable by adding next property to AppServer.properties:
```
com.scmspain.karyon.rest.property.exposeHystrixMetrics=false
```

**Releasing**
As I said before, it's not fully tested due to #21. So, please discuss this PR but do **not merge it yet**.
As this PR add a new feature, I propose to increase the minor version to **1.5**. Since it's fully backward-compatible and add a new feature.

Can you guys take a look, please?